### PR TITLE
Use new and improved source endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ experimental sdk for the socrata data-pipeline api
       - [list_operations](#list_operations-2)
       - [update](#update-1)
     + [InputSchema](#inputschema)
+      - [get_latest_output_schema](#get_latest_output_schema)
       - [latest_output](#latest_output)
       - [list_operations](#list_operations-3)
       - [transform](#transform)
@@ -292,7 +293,7 @@ Source({'content_type': None,
 ```python
 # And using that upload we just created, we can put bytes into it
 with open('test/fixtures/simple.csv', 'rb') as f:
-    (ok, input_schema) = upload.csv(f)
+    (ok, source) = upload.csv(f)
     assert ok
 ```
 ### Transforming your data
@@ -319,8 +320,9 @@ Suppose we uploaded it in our previous step, like this:
 
 ```python
 with open('temps.csv', 'rb') as f:
-    (ok, input_schema) = upload.csv(f)
+    (ok, source) = upload.csv(f)
     assert ok
+    input_schema = source.get_latest_input_schema()
 ```
 
 Our `input_schema` is the input data exactly as it appeared in the CSV, with all values of type `string`.
@@ -329,7 +331,7 @@ Our `output_schema` is the output data as it was *guessed* by Socrata. Guessing 
 like so:
 
 ```python
-(ok, output_schema) = input_schema.latest_output()
+(ok, output_schema) = input_schema.get_latest_output_schema()()
 assert ok
 ```
 
@@ -748,7 +750,7 @@ Returns:
     result (bool, dict | Revision): The closed Revision or an error
 ```
 
-#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L70)
+#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L144)
 `ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None)`
 
 Get a list of the operations that you can perform on this
@@ -828,7 +830,7 @@ be set correctly for the file handle. It's advised you don't
 use this method directly, instead use one of the csv, xls, xlsx,
 or tsv methods which will correctly set the content_type for you.
 
-#### [add_to_revision](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L196)
+#### [add_to_revision](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L209)
 `ArgSpec(args=['self', 'uri', 'revision'], varargs=None, keywords=None, defaults=None)`
 
 Associate this Source with the given revision.
@@ -879,7 +881,7 @@ Examples:
     (ok, source) = source            .change_parse_option('header_count').to(2)            .change_parse_option('column_header').to(2)            .run()
 ```
 
-#### [csv](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L61)
+#### [csv](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L74)
 `ArgSpec(args=['self', 'file_handle'], varargs=None, keywords=None, defaults=None)`
 
 Upload a CSV, returns the new input schema.
@@ -891,16 +893,16 @@ Args:
 
 Returns:
 ```
-    result (bool, InputSchema | dict): Returns an API Result; the new InputSchema or an error response
+    result (bool, Source | dict): Returns an API Result; the new Source or an error response
 ```
 
 Examples:
 ```python
     with open('my-file.csv', 'rb') as f:
-        (ok, input_schema) = upload.csv(f)
+        (ok, upload) = upload.csv(f)
 ```
 
-#### [df](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L171)
+#### [df](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L184)
 `ArgSpec(args=['self', 'dataframe'], varargs=None, keywords=None, defaults=None)`
 
 Upload a pandas DataFrame, returns the new source.
@@ -912,24 +914,24 @@ Args:
 
 Returns:
 ```
-    result (bool, InputSchema | dict): Returns an API Result; the new InputSchema or an error response
+    result (bool, Source | dict): Returns an API Result; the new Source or an error response
 ```
 
 Examples:
 ```python
     import pandas
     df = pandas.read_csv('test/fixtures/simple.csv')
-    (ok, input_schema) = upload.df(df)
+    (ok, upload) = upload.df(df)
 ```
 
-#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L70)
+#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L144)
 `ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None)`
 
 Get a list of the operations that you can perform on this
 object. These map directly onto what's returned from the API
 in the `links` section of each resource
 
-#### [shapefile](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L149)
+#### [shapefile](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L162)
 `ArgSpec(args=['self', 'file_handle'], varargs=None, keywords=None, defaults=None)`
 
 Upload a Shapefile, returns the new input schema.
@@ -941,16 +943,16 @@ Args:
 
 Returns:
 ```
-    result (bool, InputSchema | dict): Returns an API Result; the new InputSchema or an error response
+    result (bool, Source | dict): Returns an API Result; the new Source or an error response
 ```
 
 Examples:
 ```python
     with open('my-shapefile-archive.zip', 'rb') as f:
-        (ok, input_schema) = upload.shapefile(f)
+        (ok, upload) = upload.shapefile(f)
 ```
 
-#### [tsv](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L127)
+#### [tsv](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L140)
 `ArgSpec(args=['self', 'file_handle'], varargs=None, keywords=None, defaults=None)`
 
 Upload a TSV, returns the new input schema.
@@ -962,16 +964,16 @@ Args:
 
 Returns:
 ```
-    result (bool, InputSchema | dict): Returns an API Result; the new InputSchema or an error response
+    result (bool, Source | dict): Returns an API Result; the new Source or an error response
 ```
 
 Examples:
 ```python
     with open('my-file.tsv', 'rb') as f:
-        (ok, input_schema) = upload.tsv(f)
+        (ok, upload) = upload.tsv(f)
 ```
 
-#### [xls](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L83)
+#### [xls](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L96)
 `ArgSpec(args=['self', 'file_handle'], varargs=None, keywords=None, defaults=None)`
 
 Upload an XLS, returns the new input schema
@@ -983,16 +985,16 @@ Args:
 
 Returns:
 ```
-    result (bool, InputSchema | dict): Returns an API Result; the new InputSchema or an error response
+    result (bool, Source | dict): Returns an API Result; the new Source or an error response
 ```
 
 Examples:
 ```python
     with open('my-file.xls', 'rb') as f:
-        (ok, input_schema) = upload.xls(f)
+        (ok, upload) = upload.xls(f)
 ```
 
-#### [xlsx](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L105)
+#### [xlsx](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L118)
 `ArgSpec(args=['self', 'file_handle'], varargs=None, keywords=None, defaults=None)`
 
 Upload an XLSX, returns the new input schema.
@@ -1004,13 +1006,13 @@ Args:
 
 Returns:
 ```
-    result (bool, InputSchema | dict): Returns an API Result; the new InputSchema or an error response
+    result (bool, Source | dict): Returns an API Result; the new Source or an error response
 ```
 
 Examples:
 ```python
     with open('my-file.xlsx', 'rb') as f:
-        (ok, input_schema) = upload.xlsx(f)
+        (ok, upload) = upload.xlsx(f)
 ```
 
 ### [Configs](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L8)
@@ -1098,7 +1100,7 @@ in this Config.
 
 Delete this ImportConfig. Note that this cannot be undone.
 
-#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L70)
+#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L144)
 `ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None)`
 
 Get a list of the operations that you can perform on this
@@ -1116,6 +1118,14 @@ ImportConfig will take on its new value.
 
 This represents a schema exactly as it appeared in the source
 
+#### [get_latest_output_schema](https://github.com/socrata/socrata-py/blob/master//socrata/input_schema.py#L38)
+`ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None)`
+
+Note that this does not make an API request
+
+Returns:
+    output_schema (OutputSchema): Returns the latest output schema
+
 #### [latest_output](https://github.com/socrata/socrata-py/blob/master//socrata/input_schema.py#L25)
 `ArgSpec(args=['self', 'uri'], varargs=None, keywords=None, defaults=None)`
 
@@ -1125,7 +1135,7 @@ which descends from this InputSchema
 Returns:
     result (bool, OutputSchema | dict): Returns an API Result; the new OutputSchema or an error response
 
-#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L70)
+#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L144)
 `ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None)`
 
 Get a list of the operations that you can perform on this
@@ -1263,7 +1273,7 @@ Examples:
         .run()
 ```
 
-#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L70)
+#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L144)
 `ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None)`
 
 Get a list of the operations that you can perform on this
@@ -1356,7 +1366,7 @@ Returns:
 ```
 
 #### [wait_for_finish](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L75)
-`ArgSpec(args=['self', 'progress', 'timeout', 'sleeptime'], varargs=None, keywords=None, defaults=(<function noop at 0x7f15b73946a8>, None, 1))`
+`ArgSpec(args=['self', 'progress', 'timeout', 'sleeptime'], varargs=None, keywords=None, defaults=(<function noop at 0x7fc1ccb286a8>, None, 1))`
 
 Wait for this dataset to finish transforming and validating. Accepts a progress function
 and a timeout.
@@ -1371,7 +1381,7 @@ and a timeout.
 
 Has this job finished or failed
 
-#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L70)
+#### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L144)
 `ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None)`
 
 Get a list of the operations that you can perform on this
@@ -1379,7 +1389,7 @@ object. These map directly onto what's returned from the API
 in the `links` section of each resource
 
 #### [wait_for_finish](https://github.com/socrata/socrata-py/blob/master//socrata/job.py#L13)
-`ArgSpec(args=['self', 'progress'], varargs=None, keywords=None, defaults=(<function noop at 0x7f15b73946a8>,))`
+`ArgSpec(args=['self', 'progress'], varargs=None, keywords=None, defaults=(<function noop at 0x7fc1ccb286a8>,))`
 
 Wait for this job to finish applying to the underlying
 dataset

--- a/socrata/input_schema.py
+++ b/socrata/input_schema.py
@@ -1,7 +1,7 @@
 import json
 import requests
 from socrata.http import noop, post, get
-from socrata.resource import Collection, Resource
+from socrata.resource import Collection, Resource, ChildResourceSpec
 from socrata.output_schema import OutputSchema
 
 class InputSchema(Resource):
@@ -34,3 +34,24 @@ class InputSchema(Resource):
             self.path(uri),
             auth = self.auth,
         ))
+
+    def get_latest_output_schema(self):
+        """
+        Note that this does not make an API request
+
+        Returns:
+            output_schema (OutputSchema): Returns the latest output schema
+        """
+        return max(self.output_schemas, key = lambda o: o.attributes['id'])
+
+    def child_specs(self):
+        return [
+            ChildResourceSpec(
+                self,
+                'output_schemas',
+                'output_schema_links',
+                'output_schemas',
+                OutputSchema,
+                'output_schema_id'
+            )
+        ]

--- a/socrata/operations/configured_job.py
+++ b/socrata/operations/configured_job.py
@@ -15,19 +15,17 @@ class ConfiguredJob(Operation):
         if not ok:
             raise SocrataException("Failed to create the upload", source)
 
-        (ok, inp) = put_bytes(source)
+        (ok, source) = put_bytes(source)
         if not ok:
-            raise SocrataException("Failed to upload the file", inp)
+            raise SocrataException("Failed to upload the file", source)
 
-        (ok, out) = inp.latest_output()
-        if not ok:
-            raise SocrataException("Failed to get the parsed dataset")
+        output_schema = source.get_latest_input_schema().get_latest_output_schema()
 
-        (ok, out) = out.wait_for_finish()
+        (ok, output_schema) = output_schema.wait_for_finish()
         if not ok:
             raise SocrataException("The dataset failed to validate")
 
-        (ok, job) = rev.apply(output_schema = out)
+        (ok, job) = rev.apply(output_schema = output_schema)
         if not ok:
             raise SocrataException("Failed to apply the change", job)
         return (rev, job)

--- a/socrata/operations/create.py
+++ b/socrata/operations/create.py
@@ -13,16 +13,14 @@ class Create(Operation):
         if not ok:
             raise SocrataException("Failed to create the upload", source)
 
-        (ok, inp) = put_bytes(source)
+        (ok, source) = put_bytes(source)
         if not ok:
-            raise SocrataException("Failed to upload the file", inp)
+            raise SocrataException("Failed to upload the file", source)
 
-        (ok, out) = inp.latest_output()
-        if not ok:
-            raise SocrataException("Failed to get the parsed dataset")
+        output_schema = source.get_latest_input_schema().get_latest_output_schema()
 
-        (ok, out) = out.wait_for_finish()
+        (ok, output_schema) = output_schema.wait_for_finish()
         if not ok:
             raise SocrataException("The dataset failed to validate")
 
-        return (rev, out)
+        return (rev, output_schema)

--- a/socrata/resource.py
+++ b/socrata/resource.py
@@ -18,6 +18,64 @@ class Collection(object):
             return (ok, klass(self.auth, res, self))
         return result
 
+
+def parameterize_links(links, id_name, id_val):
+    d = {}
+    for name, uri in links.items():
+        if type(uri) == str:
+            d[name] = uri.replace('{%s}' % id_name, str(id_val))
+        else:
+            d[name] = parameterize_links(uri, id_name, id_val)
+    return d
+
+class ChildResourceSpec(object):
+    def __init__(
+        self,
+        parent,
+        child_list_name,
+        links_namespace,
+        response_namespace,
+        child_type,
+        link_id_attr
+    ):
+        self._parent = parent
+        self._child_list_name = child_list_name
+        self._links_namespace = links_namespace
+        self._response_namespace = response_namespace
+        self._child_type = child_type
+        self._link_id_attr = link_id_attr
+
+
+    def build_children_from(self, parent_response):
+        def build_links(child):
+
+            child_link_templates = self._parent.child_ops[self._links_namespace]
+            return parameterize_links(
+                child_link_templates,
+                self._link_id_attr,
+                child['id']
+            )
+
+        subresources = []
+        # This is the actual list of data in the parent response
+        response_list = parent_response['resource'][self._response_namespace]
+        for child in response_list:
+            child_response = {
+                'links': build_links(child),
+                'resource': child
+            }
+
+            # At this point, this looks identical to the response we receive
+            # when looking up the child via the API using a GET request,
+            # so we can just create the child resource like we would in that case
+            result = (True, child_response)
+
+            (_, subresource) = self._parent._subresource(self._child_type, result)
+            subresources.append(subresource)
+
+        return self._child_list_name, subresources
+
+
 class Resource(object):
     def __init__(self, auth, response, parent = None, *args, **kwargs):
         self.auth = auth
@@ -39,6 +97,17 @@ class Resource(object):
         self.attributes = response['resource']
         self.links = response['links']
         self._define_operations(self.links)
+        self.define_children(response)
+
+    def define_children(self, response):
+        for child_list_name, child_list in [
+            spec.build_children_from(response)
+            for spec in self.child_specs()
+        ]:
+            setattr(self, child_list_name, child_list)
+
+    def child_specs(self):
+        return []
 
     def path(self, uri):
         return 'https://{domain}{uri}'.format(
@@ -62,10 +131,15 @@ class Resource(object):
         return "%s(%s)" % (self.__class__.__name__, pprint.pformat(self.attributes))
 
     def _define_operations(self, links):
-        for name, uri in links.items():
+        self_ops = {name: uri for name, uri in links.items() if type(uri) == str}
+        child_ops = {name: d for name, d in links.items() if type(d) == dict}
+
+        for name, uri in self_ops.items():
             setattr(self, name, self._dispatch(name, uri))
             setattr(self, '%s_uri' % name, uri)
-        setattr(self, 'available_operations', links.keys())
+
+        setattr(self, 'available_operations', self_ops.keys())
+        setattr(self, 'child_ops', child_ops)
 
     def list_operations(self):
         """

--- a/test/auth.py
+++ b/test/auth.py
@@ -39,9 +39,9 @@ class TestCase(unittest.TestCase):
         (ok, source) = rev.create_upload('foo.csv')
         assert ok
         with open('test/fixtures/%s' % filename, 'rb') as f:
-            (ok, input_schema) = source.csv(f)
-            assert ok
-            return input_schema
+            (ok, source) = source.csv(f)
+            assert ok, source
+            return source.get_latest_input_schema()
 
     def create_output_schema(self, input_schema = None):
         if not input_schema:

--- a/test/import_config_test.py
+++ b/test/import_config_test.py
@@ -41,6 +41,7 @@ class ImportConfigTest(TestCase):
             "header_count": 2,
             "column_header": 2,
             "quote_char": '"',
+            "parse_source": True,
             "column_separator": ","
         })
 
@@ -78,7 +79,7 @@ class ImportConfigTest(TestCase):
         self.assertTrue(ok, config)
         self.assertEqual(config.attributes['name'], name)
 
-    def test_source_to_config(self):
+    def test_upload_to_config(self):
         p = Socrata(auth)
         name = "some_config %s" % str(uuid.uuid4())
         (ok, config) = p.configs.create(name, "replace")

--- a/test/input_schema_test.py
+++ b/test/input_schema_test.py
@@ -28,3 +28,7 @@ class TestInputSchema(TestCase):
         (ok, output_schema) = input_schema.latest_output()
         self.assertTrue(ok)
         self.assertEqual(input_schema.attributes['id'], output_schema.attributes['input_schema_id'])
+
+        nested = input_schema.get_latest_output_schema()
+
+        self.assertEqual(nested.attributes['id'], output_schema.attributes['id'])

--- a/test/output_schema_test.py
+++ b/test/output_schema_test.py
@@ -123,7 +123,6 @@ class TestOutputSchema(TestCase):
     def test_set_row_id(self):
         input_schema = self.create_input_schema()
 
-
         (ok, output_schema) = input_schema.transform({
             'output_columns': [
                 {
@@ -146,9 +145,7 @@ class TestOutputSchema(TestCase):
         self.assertEqual(output_schema.attributes['output_columns'][0]['is_primary_key'], True)
 
     def test_change_columns(self):
-        input_schema = self.create_input_schema()
-        (ok, output) = input_schema.latest_output()
-        assert ok, output
+        output = self.create_input_schema().get_latest_output_schema()
 
         (ok, output) = output\
             .change_column_metadata('a', 'field_name').to('aa')\
@@ -167,9 +164,7 @@ class TestOutputSchema(TestCase):
         self.assertEqual(c['transform']['transform_expr'], 'to_number(`c`) + 7')
 
     def test_change_column_and_reference(self):
-        input_schema = self.create_input_schema()
-        (ok, output) = input_schema.latest_output()
-        assert ok, output
+        output = self.create_input_schema().get_latest_output_schema()
 
         (ok, output) = output\
             .change_column_metadata('a', 'field_name').to('aa')\
@@ -186,9 +181,7 @@ class TestOutputSchema(TestCase):
         self.assertEqual(aa['display_name'], 'COLUMN AA!')
 
     def test_add_after_delete(self):
-        input_schema = self.create_input_schema()
-        (ok, output) = input_schema.latest_output()
-        assert ok, output
+        output = self.create_input_schema().get_latest_output_schema()
 
         (ok, output) = output\
             .drop_column('c')\
@@ -207,9 +200,7 @@ class TestOutputSchema(TestCase):
         self.assertEqual(a['display_name'], 'COLUMN AA!')
 
     def test_drop_column(self):
-        input_schema = self.create_input_schema()
-        (ok, output) = input_schema.latest_output()
-        assert ok, output
+        output = self.create_input_schema().get_latest_output_schema()
 
         (ok, output) = output\
             .change_column_metadata('a', 'field_name').to('aa')\
@@ -224,9 +215,7 @@ class TestOutputSchema(TestCase):
         self.assertEqual(aa['field_name'], 'aa')
 
     def test_create_column(self):
-        input_schema = self.create_input_schema()
-        (ok, output) = input_schema.latest_output()
-        assert ok, output
+        output = self.create_input_schema().get_latest_output_schema()
 
         (ok, output) = output\
             .change_column_metadata('a', 'field_name').to('aa')\
@@ -256,10 +245,7 @@ class TestOutputSchema(TestCase):
 
 
     def test_geocode_column(self):
-        input_schema = self.create_input_schema(filename = 'geo.csv')
-        (ok, output) = input_schema.latest_output()
-        assert ok, output
-
+        output = self.create_input_schema(filename = 'geo.csv').get_latest_output_schema()
         (ok, output) = output\
             .add_column('geocoded', 'Geocoded', 'geocode(`address`, `city`, `state`, `zip`)', 'geocoded column')\
             .drop_column('address')\

--- a/test/pandas_test.py
+++ b/test/pandas_test.py
@@ -23,7 +23,8 @@ class TestPandas(TestCase):
         assert ok
 
         df = pd.read_csv('test/fixtures/simple.csv')
-        (ok, input_schema) = source.df(df)
+        (ok, source) = source.df(df)
+        input_schema = source.get_latest_input_schema()
         self.assertTrue(ok)
         self.assertEqual(input_schema.attributes['total_rows'], 4)
 
@@ -48,8 +49,9 @@ class TestPandas(TestCase):
         (ok, source) = pub.sources.create_upload('foo.csv')
         self.assertTrue(ok, source)
         df = pd.read_csv('test/fixtures/simple.csv')
-        (ok, input_schema) = source.df(df)
-        self.assertTrue(ok, input_schema)
+        (ok, source) = source.df(df)
+        self.assertTrue(ok, source)
+        input_schema = source.get_latest_input_schema()
         names = sorted([ic['field_name'] for ic in input_schema.attributes['input_columns']])
         self.assertEqual(['a', 'b', 'c'], names)
 

--- a/test/source_test.py
+++ b/test/source_test.py
@@ -3,67 +3,70 @@ from socrata.authorization import Authorization
 from test.auth import auth, TestCase
 
 class TestSource(TestCase):
-    # def test_create_source(self):
-    #     rev = self.create_rev()
+    def test_create_source(self):
+        rev = self.create_rev()
 
-    #     (ok, source) = rev.create_upload('foo.csv')
-    #     self.assertTrue(ok)
-    #     self.assertEqual(source.attributes['source_type']['filename'], 'foo.csv')
+        (ok, source) = rev.create_upload('foo.csv')
+        self.assertTrue(ok)
+        self.assertEqual(source.attributes['source_type']['filename'], 'foo.csv')
 
-    #     assert 'show' in source.list_operations()
-    #     assert 'bytes' in source.list_operations()
+        assert 'show' in source.list_operations()
+        assert 'bytes' in source.list_operations()
 
-    # def test_upload_csv(self):
-    #     rev = self.create_rev()
-    #     (ok, source) = rev.create_upload('foo.csv')
-    #     assert ok
+    def test_upload_csv(self):
+        rev = self.create_rev()
+        (ok, source) = rev.create_upload('foo.csv')
+        assert ok
 
-    #     with open('test/fixtures/simple.csv', 'rb') as f:
-    #         (ok, input_schema) = source.csv(f)
-    #         self.assertTrue(ok)
-    #         self.assertEqual(input_schema.attributes['total_rows'], 4)
+        with open('test/fixtures/simple.csv', 'rb') as f:
+            (ok, source) = source.csv(f)
+            self.assertTrue(ok)
+            input_schema = source.get_latest_input_schema()
+            self.assertEqual(input_schema.attributes['total_rows'], 4)
 
-    #         names = sorted([ic['field_name'] for ic in input_schema.attributes['input_columns']])
-    #         self.assertEqual(['a', 'b', 'c'], names)
+            names = sorted([ic['field_name'] for ic in input_schema.attributes['input_columns']])
+            self.assertEqual(['a', 'b', 'c'], names)
 
-    #         assert 'show' in input_schema.list_operations()
+            assert 'show' in input_schema.list_operations()
 
-    # def test_create_source_outside_rev(self):
-    #     pub = Socrata(auth)
+    def test_create_source_outside_rev(self):
+        pub = Socrata(auth)
 
-    #     (ok, source) = pub.sources.create_upload('foo.csv')
-    #     self.assertTrue(ok, source)
-    #     self.assertEqual(source.attributes['source_type']['filename'], 'foo.csv')
+        (ok, source) = pub.sources.create_upload('foo.csv')
+        self.assertTrue(ok, source)
+        self.assertEqual(source.attributes['source_type']['filename'], 'foo.csv')
 
-    #     assert 'show' in source.list_operations()
-    #     assert 'bytes' in source.list_operations()
+        assert 'show' in source.list_operations()
+        assert 'bytes' in source.list_operations()
 
-    # def test_upload_csv_outside_rev(self):
-    #     pub = Socrata(auth)
+    def test_upload_csv_outside_rev(self):
+        pub = Socrata(auth)
 
-    #     (ok, source) = pub.sources.create_upload('foo.csv')
-    #     self.assertTrue(ok, source)
+        (ok, source) = pub.sources.create_upload('foo.csv')
+        self.assertTrue(ok, source)
 
-    #     with open('test/fixtures/simple.csv', 'rb') as f:
-    #         (ok, input_schema) = source.csv(f)
-    #         self.assertTrue(ok, input_schema)
-    #         names = sorted([ic['field_name'] for ic in input_schema.attributes['input_columns']])
-    #         self.assertEqual(['a', 'b', 'c'], names)
+        with open('test/fixtures/simple.csv', 'rb') as f:
+            (ok, source) = source.csv(f)
+            input_schema = source.get_latest_input_schema()
+            self.assertTrue(ok, input_schema)
+            names = sorted([ic['field_name'] for ic in input_schema.attributes['input_columns']])
+            self.assertEqual(['a', 'b', 'c'], names)
 
-    # def test_put_source_in_revision(self):
-    #     pub = Socrata(auth)
+    def test_put_source_in_revision(self):
+        pub = Socrata(auth)
 
-    #     (ok, source) = pub.sources.create_upload('foo.csv')
-    #     self.assertTrue(ok, source)
+        (ok, source) = pub.sources.create_upload('foo.csv')
+        self.assertTrue(ok, source)
 
-    #     with open('test/fixtures/simple.csv', 'rb') as f:
-    #         (ok, input_schema) = source.csv(f)
-    #         self.assertTrue(ok, input_schema)
+        with open('test/fixtures/simple.csv', 'rb') as f:
+            (ok, source) = source.csv(f)
+            input_schema = source.get_latest_input_schema()
+            self.assertTrue(ok, input_schema)
 
-    #         rev = self.create_rev()
+            rev = self.create_rev()
 
-    #         (ok, source) = source.add_to_revision(rev)
-    #         self.assertTrue(ok, source)
+            (ok, source) = source.add_to_revision(rev)
+            self.assertTrue(ok, source)
 
 
     def test_source_change_header_rows(self):
@@ -88,8 +91,8 @@ class TestSource(TestCase):
         self.assertTrue(ok, source)
 
         with open('test/fixtures/skip-header.csv', 'rb') as f:
-            (ok, input_schema) = source.csv(f)
-            self.assertTrue(ok, input_schema)
+            (ok, source) = source.csv(f)
+            self.assertTrue(ok, source)
 
 
         (ok, source) = source\
@@ -103,7 +106,7 @@ class TestSource(TestCase):
         self.assertEqual(po['header_count'], 2)
         self.assertEqual(po['column_header'], 2)
 
-        (ok, input_schema) = source.latest_input()
+        input_schema = source.get_latest_input_schema()
         self.assertTrue(ok, input_schema)
         (ok, output_schema) = input_schema.latest_output()
         self.assertTrue(ok, output_schema)


### PR DESCRIPTION
* This led to a problem where walking down the tree
  resulted in lots of API calls which is gross, since
  we already have the data (Source nests InputSchemas,
  InputSchemas nest OutputSchemas)
  * Added ChildResourceSpec which knows how to construct child
    resources from the paremeterized links returned by DSMAPI
    and the nested responses
  * Sources now has an input_schemas attribute which is a list
    of actual InputSchema objects which can be used like normal
  * InputSchema now has an output_schemas attribute which is
    a list of OutputSchema objects, constructed from the nested
    response which can be used like normal
* Updated tests
* Updated docs
* Depends on dsmapi/pull/516