### PR TITLE
change newly created dataset workflow to replace instead of update

### DIFF
--- a/socrata/revisions.py
+++ b/socrata/revisions.py
@@ -135,7 +135,7 @@ class Revisions(Collection):
             auth = auth,
             data = json.dumps({
                 'action': {
-                    'type': 'update'
+                    'type': 'replace'
                 },
                 'metadata': metadata
             })


### PR DESCRIPTION
Setting a row ID on a newly created dataset through the "create" method breaks because it is set to be an update, not replace