### PR TITLE
Fix infinite recursion bug in wait_for_finish.

### DIFF
--- a/socrata/output_schema.py
+++ b/socrata/output_schema.py
@@ -63,7 +63,6 @@ class OutputSchema(Resource):
         return Config(self.auth, res, None)
 
     def any_failed(self):
-        self.wait_for_finish()
         """
         This is probably not the function you are looking for.
 
@@ -84,12 +83,10 @@ class OutputSchema(Resource):
 
 
     def any_errors(self):
-        self.wait_for_finish()
         """
         Whether or not any transform returned a data error in this schema. This
         function will wait for processing to complete if it hasn't yet.
         """
-
         return self.attributes['error_count'] > 0
 
 


### PR DESCRIPTION
In #52, a bug was introduced to OutputSchema.any_failed which caused
calls to OutputSchema.wait_for_finish() to recurse infinitely.
wait_for_finish called any_failed for the is_failed check, which in turn
called wait_for_finish.

For small files, the transformation step finished before the maximum
recursion limit was reached, but large files resulted in a crash.