### PR TITLE
Fix possible race

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.4',
+    version='1.0.5',
 
     description="SDK For publishing to Socrata",
     long_description="""

--- a/socrata/lazy_pool.py
+++ b/socrata/lazy_pool.py
@@ -52,6 +52,7 @@ class LazyThreadPoolExecutor(object):
         return _w
 
     def _result_iterator(self):
+        done_threads = 0
         while 1:
             # Queue.get is not interruptable w/ ^C unless you specify a
             # timeout.
@@ -64,13 +65,9 @@ class LazyThreadPoolExecutor(object):
                 else:
                     yield result
             else:
-                # if all threads have exited
-                # sorry, this is kind of a gross way to use semaphores
-                # break
-                if self.thread_sem._value == self.num_workers:
+                done_threads += 1
+                if done_threads == self.num_workers:
                     break
-                else:
-                    continue
 
 
 


### PR DESCRIPTION
* it also makes the code less ugly
* i think it would have been possible for the
  _result_iterator to exit too early. if the
  following events happened:

  * last worker writes a chunk, exits semaphore
  * main thread resumes, we're in the else branch
    of the _result_iterator because another thread
    had finished
  * we see that the semaphore is no longer used by
    any worker, exit without yielding the last chunk
* this would cause us to call commit with one sequence number
  less than we actually wrote
* that is the behavior i see sometimes
* fix is to track worker completion by keeping track
  of the amount of THREAD_DONE results
* all exceptions get wrapped and re-raised in the main thread,
  so we shouldn't have to worry about an exception happening
  and not returning a THREAD_DONE