### PR TITLE
Add "external_datasets" field to Revision

### DIFF
--- a/socrata/__init__.py
+++ b/socrata/__init__.py
@@ -97,7 +97,7 @@ class Socrata(Collection):
         """
         return Create(self, metadata=kwargs)
 
-    def new(self, metadata):
+    def new(self, metadata, external_datasets=[]):
         """
         Create an empty revision, on a view that doesn't exist yet. The
         view will be created for you, and the initial revision will be returned.
@@ -125,7 +125,7 @@ class Socrata(Collection):
             })
         ```
         """
-        return Revisions.new(self.auth, metadata)
+        return Revisions.new(self.auth, metadata, external_datasets)
 
 
 __all__ = [

--- a/socrata/__init__.py
+++ b/socrata/__init__.py
@@ -105,6 +105,7 @@ class Socrata(Collection):
         Args:
         ```
             metadata (dict): Metadata to apply to the revision
+            external_datasets ([dict]): List of external datasets to apply to revision
         ```
 
         Returns:
@@ -115,14 +116,22 @@ class Socrata(Collection):
         Examples:
         ```python
             rev = Socrata(auth).new({
-                'name': 'hi',
-                'description': 'foo!',
-                'metadata': {
-                    'view': 'metadata',
-                    'anything': 'is allowed here'
-
-                }
-            })
+                     'name': 'hi',
+                     'description': 'foo!',
+                     'metadata': {
+                       'view': 'metadata',
+                       'anything': 'is allowed here'
+                     }
+                   }, 
+                   external_datasets=[{
+                    'title' :  'Associated search engines',
+                    'description' : 'Why would you use any of these?',
+                    'urls' : {
+                      'lycos' : 'http://www.altavista.com/',
+                      'altavista' : 'http://www.altavista.com/',
+                      'yahoo' : 'http://www.yahoo.com/'
+                    }
+                  }])
         ```
         """
         return Revisions.new(self.auth, metadata, external_datasets)

--- a/socrata/revisions.py
+++ b/socrata/revisions.py
@@ -133,7 +133,7 @@ class Revisions(Collection):
         ```
             auth (Socrata.Authorization): 
             metadata (dict): Metadata to apply to the revision 
-            external_datasets ( [dict] ): List of external datasets to apply to the revision
+            external_datasets ([dict]): List of external datasets to apply to revision
         ```
 
         Returns:


### PR DESCRIPTION
Resolves #45 

 If you look at the code for [Revisions.new](https://github.com/socrata/socrata-py/blob/master/socrata/revisions.py):
```
@staticmethod
def new(auth, metadata):
    path = 'https://{domain}/api/publishing/v1/revision'.format(
        domain = auth.domain,
    )

    response = post(
        path,
        auth = auth,
        data = json.dumps({
            'action': {
                'type': 'update'
            },
            'metadata': metadata
        })
    )
    return Revision(auth, response)
```

The revision's JSON data has two top-level attributes, `action` and `metadata`. However, if you look at Socrata's [Publishing api](https://socratapublishing.docs.apiary.io/#reference/0/inputschema) (which socrata-py wraps around), you'll see that in order to add an external URL, you need a third top-level attribute, `href` (pictured below).

![Socrata Publishing API](https://i.imgur.com/zlXtmwp.png)

I've added a small amount of code to allow users to specify external datasets when creating new Revisions