### PR TITLE
Fix missing import in resource module

### DIFF
--- a/socrata/resource.py
+++ b/socrata/resource.py
@@ -1,6 +1,6 @@
 import time
 import pprint
-from socrata.http import noop, get, TimeoutException
+from socrata.http import noop, get, TimeoutException, UnexpectedResponseException
 from requests.exceptions import RequestException
 import requests
 


### PR DESCRIPTION
The `resource` module includes a reference to `UnexpectedResponseException` but does not actually import it, causing Socrata-py to fail with a `NameError` under certain conditions. This fixes the missing import.