### PR TITLE
Update README with dataset 'permission' information

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ auth = Authorization(
 
 
 #### Create a new Dataset from a csv, tsv, xls or xlsx file
+Datasets are made Public by default. To make a dataset private, see the [Revision](#revision) section notes on default values for the 'permission' parameter.
 To create a dataset, you can do this:
 
 ```python


### PR DESCRIPTION
Added note about dataset privacy in README.

Users were telling us there is nothing in documentation about making datasets private. Added a sentence in the "Using" section to direct them appropriately.