### PR TITLE
NO_JIRA: add 5 second breaks in some tests

### DIFF
--- a/test/import_config_test.py
+++ b/test/import_config_test.py
@@ -4,6 +4,7 @@ from socrata.authorization import Authorization
 from test.auth import auth, TestCase
 import uuid
 from socrata.http import UnexpectedResponseException
+import time
 
 class ImportConfigTest(TestCase):
     def test_create_config(self):
@@ -61,6 +62,7 @@ class ImportConfigTest(TestCase):
         p = Socrata(auth)
         name = "some_config %s" % str(uuid.uuid4())
         config = p.configs.create(name, "replace")
+        time.sleep(5)
 
         configs = p.configs.list()
 
@@ -129,6 +131,7 @@ class ImportConfigTest(TestCase):
         p = Socrata(auth)
         name = "some_config %s" % str(uuid.uuid4())
         config = p.configs.create(name, "replace")
+        time.sleep(5)
 
         _ = config.delete()
 

--- a/test/pandas_test.py
+++ b/test/pandas_test.py
@@ -1,11 +1,13 @@
 from socrata import Socrata
 from socrata.authorization import Authorization
 from auth import auth, TestCase
+import time
 try:
     import pandas as pd
 except ImportError:
     print("Pandas is required for this test")
     exit()
+    
 class TestPandas(TestCase):
     def test_create_source(self):
         rev = self.create_rev()
@@ -19,6 +21,7 @@ class TestPandas(TestCase):
     def test_source_csv(self):
         rev = self.create_rev()
         source = rev.create_upload('foo.csv')
+        time.sleep(5)
 
         df = pd.read_csv('test/fixtures/simple.csv')
         source = source.df(df)

--- a/test/source_test.py
+++ b/test/source_test.py
@@ -2,6 +2,7 @@ from socrata import Socrata
 from socrata.authorization import Authorization
 from test.auth import auth, TestCase
 import uuid
+import time
 
 class TestSource(TestCase):
     def test_create_source(self):
@@ -94,6 +95,7 @@ class TestSource(TestCase):
     def test_upload_shapefile(self):
         rev = self.create_rev()
         source = rev.create_upload('wards.zip')
+        time.sleep(5)
 
         with open('test/fixtures/wards.zip', 'rb') as f:
             source = source.shapefile(f)
@@ -168,6 +170,7 @@ class TestSource(TestCase):
     def test_upload_csv_outside_rev(self):
         pub = Socrata(auth)
         source = pub.sources.create_upload('foo.csv')
+        time.sleep(5)
 
         with open('test/fixtures/simple.csv', 'rb') as f:
             source = source.csv(f)
@@ -212,7 +215,7 @@ class TestSource(TestCase):
             .change_parse_option('column_header').to(2)\
             .run()
 
-        source = source.wait_for_finish(timeout = 300)
+        source = source.wait_for_finish(timeout = 600)
 
         po = source.attributes['parse_options']
         self.assertEqual(po['header_count'], 2)


### PR DESCRIPTION
added sleep(5) to make sure the calls before it are completed before we do next steps