### PR TITLE
EN-93390 - let revisions retain permissions from pervious revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # socrata-py
+
 Python SDK for the Socrata Data Management API. Use this library to call into publishing and ETL functionality offered when writing to Socrata datasets.
 
 ```python
@@ -13,120 +14,142 @@ with open('cool_dataset.csv', 'rb') as file:
 
 <!-- toc -->
 
-  * [Installation](#installation)
-  * [Example](#example)
-  * [Using](#using)
-    + [Boilerplate](#boilerplate)
-    + [Simple usage](#simple-usage)
+- [Installation](#installation)
+- [Example](#example)
+- [Using](#using)
+  - [Boilerplate](#boilerplate)
+  - [Simple usage](#simple-usage)
+    - [Create a new Dataset from a csv, tsv, xls or xlsx file](#create-a-new-dataset-from-a-csv-tsv-xls-or-xlsx-file)
+    - [Create a new Dataset from Pandas](#create-a-new-dataset-from-pandas)
+    - [Updating a dataset](#updating-a-dataset)
+    - [Generating a config and using it to update](#generating-a-config-and-using-it-to-update)
+- [Advanced usage](#advanced-usage)
+  - [Create a revision](#create-a-revision)
+  - [Create an upload](#create-an-upload)
+  - [Upload a file](#upload-a-file)
+  - [Transforming your data](#transforming-your-data)
+  - [Wait for the transformation to finish](#wait-for-the-transformation-to-finish)
+  - [Errors in a transformation](#errors-in-a-transformation)
+  - [Validating rows](#validating-rows)
+  - [Do the upsert!](#do-the-upsert)
+  - [Metadata only revisions](#metadata-only-revisions)
+
+* [socrata-py](#socrata-py)
+  - [Installation](#installation)
+  - [Example](#example)
+  - [Using](#using)
+    - [Boilerplate](#boilerplate)
+    - [Simple usage](#simple-usage)
       - [Create a new Dataset from a csv, tsv, xls or xlsx file](#create-a-new-dataset-from-a-csv-tsv-xls-or-xlsx-file)
       - [Create a new Dataset from Pandas](#create-a-new-dataset-from-pandas)
       - [Updating a dataset](#updating-a-dataset)
       - [Generating a config and using it to update](#generating-a-config-and-using-it-to-update)
-  * [Advanced usage](#advanced-usage)
-    + [Create a revision](#create-a-revision)
-    + [Create an upload](#create-an-upload)
-    + [Upload a file](#upload-a-file)
-    + [Transforming your data](#transforming-your-data)
-    + [Wait for the transformation to finish](#wait-for-the-transformation-to-finish)
-    + [Errors in a transformation](#errors-in-a-transformation)
-    + [Validating rows](#validating-rows)
-    + [Do the upsert!](#do-the-upsert)
-    + [Metadata only revisions](#metadata-only-revisions)
-- [Development](#development)
-  * [Testing](#testing)
-  * [Generating docs](#generating-docs)
-  * [Releasing](#releasing)
-- [Library Docs](#library-docs)
-    + [Socrata](#socrata)
-      - [create](#create)
-      - [new](#new)
-      - [using_config](#using_config)
-    + [Authorization](#authorization)
-      - [live_dangerously](#live_dangerously)
-    + [Revisions](#revisions)
-      - [create_delete_revision](#create_delete_revision)
-      - [create_replace_revision](#create_replace_revision)
-      - [create_update_revision](#create_update_revision)
-      - [create_using_config](#create_using_config)
-      - [list](#list)
-      - [lookup](#lookup)
-    + [Revision](#revision)
-      - [apply](#apply)
-      - [create_upload](#create_upload)
-      - [discard](#discard)
-      - [list_operations](#list_operations)
-      - [open_in_browser](#open_in_browser)
-      - [plan](#plan)
-      - [set_notes](#set_notes)
-      - [set_output_schema](#set_output_schema)
-      - [source_as_blob](#source_as_blob)
-      - [source_from_agent](#source_from_agent)
-      - [source_from_dataset](#source_from_dataset)
-      - [source_from_url](#source_from_url)
-      - [ui_url](#ui_url)
-      - [update](#update)
-    + [Sources](#sources)
-      - [create_upload](#create_upload-1)
-      - [lookup](#lookup-1)
-    + [Source](#source)
-      - [add_to_revision](#add_to_revision)
-      - [blob](#blob)
-      - [change_parse_option](#change_parse_option)
-      - [csv](#csv)
-      - [df](#df)
-      - [geojson](#geojson)
-      - [kml](#kml)
-      - [list_operations](#list_operations-1)
-      - [load](#load)
-      - [open_in_browser](#open_in_browser-1)
-      - [shapefile](#shapefile)
-      - [tsv](#tsv)
-      - [ui_url](#ui_url-1)
-      - [wait_for_finish](#wait_for_finish)
-      - [wait_for_schema](#wait_for_schema)
-      - [xls](#xls)
-      - [xlsx](#xlsx)
-    + [Configs](#configs)
-      - [create](#create-1)
-      - [list](#list-1)
-      - [lookup](#lookup-2)
-    + [Config](#config)
-      - [change_parse_option](#change_parse_option-1)
-      - [create_revision](#create_revision)
-      - [delete](#delete)
-      - [list_operations](#list_operations-2)
-      - [update](#update-1)
-    + [InputSchema](#inputschema)
-      - [get_latest_output_schema](#get_latest_output_schema)
-      - [latest_output](#latest_output)
-      - [list_operations](#list_operations-3)
-      - [transform](#transform)
-      - [wait_for_schema](#wait_for_schema-1)
-    + [OutputSchema](#outputschema)
-      - [add_column](#add_column)
-      - [any_failed](#any_failed)
-      - [build_config](#build_config)
-      - [change_column_metadata](#change_column_metadata)
-      - [change_column_transform](#change_column_transform)
-      - [drop_column](#drop_column)
-      - [list_operations](#list_operations-4)
-      - [rows](#rows)
-      - [run](#run)
-      - [schema_errors](#schema_errors)
-      - [schema_errors_csv](#schema_errors_csv)
-      - [set_row_id](#set_row_id)
-      - [set_sort_by](#set_sort_by)
-      - [validate_row_id](#validate_row_id)
-      - [wait_for_finish](#wait_for_finish-1)
-    + [Job](#job)
-      - [is_complete](#is_complete)
-      - [list_operations](#list_operations-5)
-      - [submitted_for_approval](#submitted_for_approval)
-      - [wait_for_finish](#wait_for_finish-2)
+  - [Advanced usage](#advanced-usage)
+    - [Create a revision](#create-a-revision)
+    - [Create an upload](#create-an-upload)
+    - [Upload a file](#upload-a-file)
+    - [Transforming your data](#transforming-your-data)
+    - [Wait for the transformation to finish](#wait-for-the-transformation-to-finish)
+    - [Errors in a transformation](#errors-in-a-transformation)
+    - [Validating rows](#validating-rows)
+    - [Do the upsert!](#do-the-upsert)
+    - [Metadata only revisions](#metadata-only-revisions)
+* [Development](#development)
+  - [Testing](#testing)
+  - [Generating docs](#generating-docs)
+  - [Releasing](#releasing)
+* [Library Docs](#library-docs)
+  - [Socrata](#socrata)
+    - [create](#create)
+    - [new](#new)
+    - [using_config](#using_config)
+  - [Authorization](#authorization)
+    - [live_dangerously](#live_dangerously)
+  - [Revisions](#revisions)
+    - [create_delete_revision](#create_delete_revision)
+    - [create_replace_revision](#create_replace_revision)
+    - [create_update_revision](#create_update_revision)
+    - [create_using_config](#create_using_config)
+    - [list](#list)
+    - [lookup](#lookup)
+  - [Revision](#revision)
+    - [apply](#apply)
+    - [create_upload](#create_upload)
+    - [discard](#discard)
+    - [list_operations](#list_operations)
+    - [open_in_browser](#open_in_browser)
+    - [plan](#plan)
+    - [set_notes](#set_notes)
+    - [set_output_schema](#set_output_schema)
+    - [source_as_blob](#source_as_blob)
+    - [source_from_agent](#source_from_agent)
+    - [source_from_dataset](#source_from_dataset)
+    - [source_from_url](#source_from_url)
+    - [ui_url](#ui_url)
+    - [update](#update)
+  - [Sources](#sources)
+    - [create_upload](#create_upload-1)
+    - [lookup](#lookup-1)
+  - [Source](#source)
+    - [add_to_revision](#add_to_revision)
+    - [blob](#blob)
+    - [change_parse_option](#change_parse_option)
+    - [csv](#csv)
+    - [df](#df)
+    - [geojson](#geojson)
+    - [kml](#kml)
+    - [list_operations](#list_operations-1)
+    - [load](#load)
+    - [open_in_browser](#open_in_browser-1)
+    - [shapefile](#shapefile)
+    - [tsv](#tsv)
+    - [ui_url](#ui_url-1)
+    - [wait_for_finish](#wait_for_finish)
+    - [wait_for_schema](#wait_for_schema)
+    - [xls](#xls)
+    - [xlsx](#xlsx)
+  - [Configs](#configs)
+    - [create](#create-1)
+    - [list](#list-1)
+    - [lookup](#lookup-2)
+  - [Config](#config)
+    - [change_parse_option](#change_parse_option-1)
+    - [create_revision](#create_revision)
+    - [delete](#delete)
+    - [list_operations](#list_operations-2)
+    - [update](#update-1)
+  - [InputSchema](#inputschema)
+    - [get_latest_output_schema](#get_latest_output_schema)
+    - [latest_output](#latest_output)
+    - [list_operations](#list_operations-3)
+    - [transform](#transform)
+    - [wait_for_schema](#wait_for_schema-1)
+  - [OutputSchema](#outputschema)
+    - [add_column](#add_column)
+    - [any_failed](#any_failed)
+    - [build_config](#build_config)
+    - [change_column_metadata](#change_column_metadata)
+    - [change_column_transform](#change_column_transform)
+    - [drop_column](#drop_column)
+    - [list_operations](#list_operations-4)
+    - [rows](#rows)
+    - [run](#run)
+    - [schema_errors](#schema_errors)
+    - [schema_errors_csv](#schema_errors_csv)
+    - [set_row_id](#set_row_id)
+    - [set_sort_by](#set_sort_by)
+    - [validate_row_id](#validate_row_id)
+    - [wait_for_finish](#wait_for_finish-1)
+  - [Job](#job)
+    - [is_complete](#is_complete)
+    - [list_operations](#list_operations-5)
+    - [submitted_for_approval](#submitted_for_approval)
+    - [wait_for_finish](#wait_for_finish-2)
 
 <!-- tocstop -->
 
 ## Installation
+
 This only supports python3.
 
 Installation is available through pip. Using a virtualenv is advised. Install
@@ -138,15 +161,18 @@ pip3 install socrata-py
 
 The only hard dependency is `requests` which will be installed via pip. Pandas is not required, but creating a dataset from a Pandas dataframe is supported. See below.
 
-
 ## Example
+
 Try the command line example with
+
 ```bash
 python -m examples.create 'Police Reports' ~/Desktop/catalog.data.gov/Seattle_Real_Time_Fire_911_Calls.csv 'pete-test.test-socrata.com' --username $SOCRATA_USERNAME --password $SOCRATA_PASSWORD
 ```
+
 ## Using
 
 ### Boilerplate
+
 ```python
 # Import some stuff
 from socrata.authorization import Authorization
@@ -165,8 +191,8 @@ auth = Authorization(
 
 ### Simple usage
 
-
 #### Create a new Dataset from a csv, tsv, xls or xlsx file
+
 To create a dataset, you can do this:
 
 ```python
@@ -222,7 +248,9 @@ those files.
 There is a `blob` method as well, which uploads blobby data to the source. This means the data will not be parsed, and will be displayed under "Files and Documents" in the catalog once the revision is applied.
 
 #### Create a new Dataset from Pandas
+
 Datasets can also be created from Pandas DataFrames
+
 ```python
 import pandas as pd
 df = pd.read_csv('socrata-py/test/fixtures/simple.csv')
@@ -237,11 +265,13 @@ df = pd.read_csv('socrata-py/test/fixtures/simple.csv')
 ```
 
 #### Updating a dataset
+
 A Socrata `update` is actually an upsert. Rows are updated or created based on the row identifier. If the row-identifer doesn't exist, all updates are just appends to the dataset.
 
 A `replace` truncates the whole dataset and then inserts the new data.
 
 #### Generating a config and using it to update
+
 ```python
 # This is how we create our view initially
 with open('cool_dataset.csv', 'rb') as file:
@@ -274,7 +304,6 @@ with open('updated-cool-dataset.csv', 'rb') as my_file:
     print(job) # Our update job is now running
 ```
 
-
 ## Advanced usage
 
 ### Create a revision
@@ -304,6 +333,7 @@ print(revision.attributes['metadata']['name'])
 ```
 
 ### Create an upload
+
 ```python
 # Using that revision, we can create an upload
 upload = revision.create_upload('foo.csv')
@@ -323,13 +353,17 @@ Source({'content_type': None,
  'inserted_at': '2017-02-27T23:07:18.309676',
  'schemas': []})
 ```
+
 ### Upload a file
+
 ```python
 # And using that upload we just created, we can put bytes into it
 with open('test/fixtures/simple.csv', 'rb') as f:
     source = upload.csv(f)
 ```
+
 ### Transforming your data
+
 Transforming data consists of going from input data (data exactly as it appeared in the source)
 to output data (data as you want it to appear).
 
@@ -339,6 +373,7 @@ a number. Rather than failing at each datum which is dirty or wrong, transformin
 reconcile these issues.
 
 We might have a dataset called `temps.csv` that looks like
+
 ```
 date, celsius
 8-24-2017, 22
@@ -359,7 +394,7 @@ with open('temps.csv', 'rb') as f:
 
 Our `input_schema` is the input data exactly as it appeared in the CSV, with all values of type `string`.
 
-Our `output_schema` is the output data as it was *guessed* by Socrata. Guessing may not always be correct, which is why we have import configs to "lock in" a schema for automation. We can get the `output_schema`
+Our `output_schema` is the output data as it was _guessed_ by Socrata. Guessing may not always be correct, which is why we have import configs to "lock in" a schema for automation. We can get the `output_schema`
 like so:
 
 ```python
@@ -396,9 +431,9 @@ We can also call `drop_column(celsius)` which will drop the column.
 
 Transforms can be complex SoQL expressions. Available functions are listed [here](http://docs.socratapublishing.apiary.io/#reference/0/inputschema). You can do lots of stuff with them;
 
-
 For example, you could change all `null` values into errors (which won't be imported) by doing
 something like
+
 ```python
 new_output_schema = output
     .change_column_transform('celsius').to('coalesce(to_number(`celsius`), error("Celsius was null!"))')
@@ -406,6 +441,7 @@ new_output_schema = output
 ```
 
 Or you could add a new column that says if the day was hot or not
+
 ```python
 new_output_schema = output
     .add_column('is_hot', 'Was the day hot?', 'to_number(`celsius`) >= 23')
@@ -413,6 +449,7 @@ new_output_schema = output
 ```
 
 Or you could geocode a column, given the following CSV
+
 ```
 address,city,zip,state
 10028 Ravenna Ave NE, Seattle, 98128, WA
@@ -433,32 +470,40 @@ output = output\
     .run()
 ```
 
-
 Composing these SoQL functions into expressions will allow you to validate, shape, clean and extend your data to make it more useful to the consumer.
 
 ### Wait for the transformation to finish
+
 Transformations are async, so if you want to wait for it to finish, you can do so
+
 ```ok output_schema) = new_output_schema.wait_for_finish()
+
 ```
 
 ### Errors in a transformation
+
 Transformations may have had errors, like in the previous example, we can't convert `hehe!` to a number. We can see the count of them like this:
+
 ```python
 print(output_schema.attributes['error_count'])
 ```
 
 We can view the detailed errors like this:
+
 ```python
 errors = output_schema.schema_errors()
 ```
 
 We can get a CSV of the errors like this:
+
 ```python
 csv_stream = output_schema.schema_errors_csv()
 ```
 
 ### Validating rows
+
 We can look at the rows of our schema as well
+
 ```python
 rows = output_schema.rows(offset = 0, limit = 20)
 
@@ -471,6 +516,7 @@ self.assertEqual(rows, [
 ```
 
 ### Do the upsert!
+
 ```python
 # Now we have transformed our data into the shape we want, let's do an upsert
 job = revision.apply(output_schema = output_schema)
@@ -496,6 +542,7 @@ job.wait_for_finish(progress = lambda job: print(job.attributes['log']))
 ```
 
 ### Metadata only revisions
+
 When there is an existing Socrata view that you'd like to update the metadata of, you can do so by creating a Source which is the Socrata view.
 
 ```python
@@ -513,29 +560,36 @@ new_output_schema = output_schema\
 
 revision.apply(output_schema = new_output_schema)
 ```
+
 # Development
 
 ## Testing
+
 Install test deps by running `pip install -r requirements.txt`. This will install `pdoc` and `pandas` which are required to run the tests.
 
 Configuration is set in `test/auth.py` for tests. It reads the domain, username, and password from environment variables. If you want to run the tests, set those environment variables to something that will work.
 
 If I wanted to run the tests against my local instance, I would run:
+
 ```bash
 SOCRATA_DOMAIN=localhost SOCRATA_USERNAME=$SOCRATA_LOCAL_USER SOCRATA_PASSWORD=$SOCRATA_LOCAL_PASS bin/test
 ```
 
 ## Generating docs
+
 make the docs by running
+
 ```bash
 make docs
 ```
 
 ## Releasing
+
 You will need to have [twine](https://pypi.org/project/twine/) installed (`pip3 install twine`), and a `.pypirc` file in your home directory.
 For help, read [this](https://web.archive.org/web/20180523182143/http://peterdowns.com/posts/first-time-with-pypi.html)
 
 An example of a pypirc file looks like:
+
 ```
 [distutils]
 index-servers =
@@ -561,9 +615,11 @@ twine upload dist/<your distribution file>
 ```
 
 <!-- doc -->
+
 # Library Docs
 
 ### [Socrata](https://github.com/socrata/socrata-py/blob/master//socrata/__init__.py#L9)
+
 ```
 ArgSpec
     Args: auth
@@ -579,13 +635,13 @@ In the event of a socket hangup, an exception is raised.
 
 #### [create](https://github.com/socrata/socrata-py/blob/master//socrata/__init__.py#L61)
 
-
 Shortcut to create a dataset. Returns a `Create` object,
 which contains functions which will create a view, upload
 your file, and validate data quality in one step.
 
 To actually place the validated data into a view, you can call .apply()
 on the revision
+
 ```
 (revision, output_schema) Socrata(auth).create(
     name = "cool dataset",
@@ -596,17 +652,20 @@ job = revision.apply(output_schema = output_schema)
 ```
 
 Args:
+
 ```
    **kwargs: Arbitrary revision metadata values
 ```
 
 Returns:
+
 ```
     result (Revision, OutputSchema): Returns the revision that was created and the
         OutputSchema created from your uploaded file
 ```
 
 Examples:
+
 ```python
 Socrata(auth).create(
     name = "cool dataset",
@@ -615,6 +674,7 @@ Socrata(auth).create(
 ```
 
 #### [new](https://github.com/socrata/socrata-py/blob/master//socrata/__init__.py#L100)
+
 ```
 ArgSpec
     Args: metadata, deleted_at
@@ -624,16 +684,19 @@ Create an empty revision, on a view that doesn't exist yet. The
 view will be created for you, and the initial revision will be returned.
 
 Args:
+
 ```
     metadata (dict): Metadata to apply to the revision
 ```
 
 Returns:
+
 ```
     Revision
 ```
 
 Examples:
+
 ```python
     rev = Socrata(auth).new({
         'name': 'hi',
@@ -647,6 +710,7 @@ Examples:
 ```
 
 #### [using_config](https://github.com/socrata/socrata-py/blob/master//socrata/__init__.py#L28)
+
 ```
 ArgSpec
     Args: config_name, view
@@ -658,28 +722,32 @@ which uniquely identifies the config, and the `View` object, which can
 be obtained from `socrata.views.lookup('view-id42')`
 
 Args:
+
 ```
     config_name (str): The config name
     view (View): The view to update
 ```
 
 Returns:
+
 ```
     result (ConfiguredJob): Returns the ConfiguredJob
 ```
 
 Note:
-    Typical usage would be in a context manager block (as demonstrated in the example
-    below). In this case, the `ConfiguredJob` is created and immediately launched by way of
-    the call to the `ConfiguredJob.csv` method.
+Typical usage would be in a context manager block (as demonstrated in the example
+below). In this case, the `ConfiguredJob` is created and immediately launched by way of
+the call to the `ConfiguredJob.csv` method.
 
 Examples:
+
 ```
     with open('my-file.csv', 'rb') as my_file:
         (rev, job) = p.using_config(name, view).csv(my_file)
 ```
 
 ### [Authorization](https://github.com/socrata/socrata-py/blob/master//socrata/authorization.py#L3)
+
 ```
 ArgSpec
     Args: domain, username, password, request_id_prefix
@@ -699,23 +767,22 @@ point for all operations.
 
 #### [live_dangerously](https://github.com/socrata/socrata-py/blob/master//socrata/authorization.py#L28)
 
-
-Disable SSL checking. Note that this should *only* be used while developing
+Disable SSL checking. Note that this should _only_ be used while developing
 against a local Socrata instance.
 
 ### [Revisions](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L9)
+
 ```
 ArgSpec
     Args: fourfour, auth
 ```
 
-
-
 #### [create_delete_revision](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L100)
+
 ```
 ArgSpec
     Args: metadata, permission
-    Defaults: metadata={}, permission=public
+    Defaults: metadata={}, permission=None
 ```
 
 Create a revision on the view, which when applied, will delete rows of data.
@@ -723,17 +790,20 @@ Create a revision on the view, which when applied, will delete rows of data.
 This is an upsert; a row id must be set.
 
 Args:
+
 ```
     metadata (dict): The metadata to change; these changes will be applied when the revision is applied
     permission (string): 'public' or 'private'
 ```
 
 Returns:
+
 ```
     Revision The new revision, or an error
 ```
 
 Examples:
+
 ```python
     view.revisions.create_delete_revision(metadata = {
         'name': 'new dataset name',
@@ -742,34 +812,41 @@ Examples:
 ```
 
 #### [create_replace_revision](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L50)
+
 ```
 ArgSpec
     Args: metadata, permission
-    Defaults: metadata={}, permission=public
+    Defaults: metadata={}, permission=None
 ```
 
 Create a revision on the view, which when applied, will replace the data.
 
 Args:
+
 ```
     metadata (dict): The metadata to change; these changes will be applied when the revision
         is applied
     permission (string): 'public' or 'private'
 ```
+
 Returns:
+
 ```
     Revision The new revision, or an error
 ```
+
 Examples:
+
 ```
     >>> view.revisions.create_replace_revision(metadata = {'name': 'new dataset name', 'description': 'updated description'})
 ```
 
 #### [create_update_revision](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L71)
+
 ```
 ArgSpec
     Args: metadata, permission
-    Defaults: metadata={}, permission=public
+    Defaults: metadata={}, permission=None
 ```
 
 Create a revision on the view, which when applied, will update the data
@@ -779,17 +856,20 @@ This is an upsert; if there is a rowId defined and you have duplicate ID values,
 those rows will be updated. Otherwise they will be appended.
 
 Args:
+
 ```
     metadata (dict): The metadata to change; these changes will be applied when the revision is applied
     permission (string): 'public' or 'private'
 ```
 
 Returns:
+
 ```
     Revision The new revision, or an error
 ```
 
 Examples:
+
 ```python
     view.revisions.create_update_revision(metadata = {
         'name': 'new dataset name',
@@ -798,6 +878,7 @@ Examples:
 ```
 
 #### [create_using_config](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L165)
+
 ```
 ArgSpec
     Args: config
@@ -807,15 +888,16 @@ Create a revision for the given dataset.
 
 #### [list](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L35)
 
-
 List all the revisions on the view
 
 Returns:
+
 ```
     list[Revision]
 ```
 
 #### [lookup](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L146)
+
 ```
 ArgSpec
     Args: revision_seq
@@ -824,16 +906,19 @@ ArgSpec
 Lookup a revision within the view based on the sequence number
 
 Args:
+
 ```
     revision_seq (int): The sequence number of the revision to lookup
 ```
 
 Returns:
+
 ```
     Revision The Revision resulting from this API call, or an error
 ```
 
 ### [Revision](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L178)
+
 ```
 ArgSpec
     Args: auth, response, parent
@@ -842,6 +927,7 @@ ArgSpec
 A revision is a change to a dataset
 
 #### [apply](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L383)
+
 ```
 ArgSpec
     Args: output_schema
@@ -850,6 +936,7 @@ ArgSpec
 Apply the Revision to the view that it was opened on
 
 Args:
+
 ```
     output_schema (OutputSchema): Optional output schema. If your revision includes
         data changes, this should be included. If it is a metadata only revision,
@@ -858,16 +945,19 @@ Args:
 ```
 
 Returns:
+
 ```
     Job
 ```
 
 Examples:
+
 ```
 job = revision.apply(output_schema = my_output_schema)
 ```
 
 #### [create_upload](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L183)
+
 ```
 ArgSpec
     Args: filename, parse_options
@@ -877,26 +967,28 @@ ArgSpec
 Create an upload within this revision
 
 Args:
+
 ```
     filename (str): The name of the file to upload
 ```
+
 Returns:
+
 ```
     Source: Returns the new Source The Source created by this API call, or an error
 ```
 
 #### [discard](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L329)
 
-
 Discard this open revision.
 
 Returns:
+
 ```
     Revision The closed Revision or an error
 ```
 
 #### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L146)
-
 
 Get a list of the operations that you can perform on this
 object. These map directly onto what's returned from the API
@@ -904,20 +996,20 @@ in the `links` section of each resource
 
 #### [open_in_browser](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L447)
 
-
 Open this revision in your browser, this will open a window
 
 #### [plan](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L340)
 
-
 Return the list of operations this revision will make when it is applied
 
 Returns:
+
 ```
     dict
 ```
 
 #### [set_notes](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L301)
+
 ```
 ArgSpec
     Args: notes
@@ -928,21 +1020,25 @@ changelog if the dataset is enrolled in archiving. If it is not enrolled
 in archiving, this has no effect.
 
 Args:
+
 ```
     notes (string): The change notes
 ```
 
 Returns:
+
 ```
     Revision The updated Revision as a result of this API call, or an error
 ```
 
 Examples:
+
 ```python
     revision = revision.set_notes("Just updating my dataset")
 ```
 
 #### [set_output_schema](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L279)
+
 ```
 ArgSpec
     Args: output_schema_id
@@ -952,21 +1048,25 @@ Set the output schema id on the revision. This is what will get applied when
 the revision is applied if no ouput schema is explicitly supplied
 
 Args:
+
 ```
     output_schema_id (int): The output schema id
 ```
 
 Returns:
+
 ```
     Revision The updated Revision as a result of this API call, or an error
 ```
 
 Examples:
+
 ```python
     revision = revision.set_output_schema(42)
 ```
 
 #### [source_as_blob](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L240)
+
 ```
 ArgSpec
     Args: filename, parse_options
@@ -976,6 +1076,7 @@ ArgSpec
 Create a source from a file that should remain unparsed
 
 #### [source_from_agent](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L228)
+
 ```
 ArgSpec
     Args: agent_uid, namespace, path, parse_options, parameters
@@ -985,6 +1086,7 @@ ArgSpec
 Create a source from a connection agent in this revision
 
 #### [source_from_dataset](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L219)
+
 ```
 ArgSpec
     Args: parse_options
@@ -994,6 +1096,7 @@ ArgSpec
 Create a dataset source within this revision
 
 #### [source_from_url](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L201)
+
 ```
 ArgSpec
     Args: url, parse_options
@@ -1003,25 +1106,29 @@ ArgSpec
 Create a URL source
 
 Args:
+
 ```
     url (str): The URL to create the dataset from
 ```
+
 Returns:
+
 ```
     Source: Returns the new Source The Source created by this API call, or an error
 ```
 
 #### [ui_url](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L432)
 
-
 This is the URL to the landing page in the UI for this revision
 
 Returns:
+
 ```
     url (str): URL you can paste into a browser to view the revision UI
 ```
 
 #### [update](https://github.com/socrata/socrata-py/blob/master//socrata/revisions.py#L352)
+
 ```
 ArgSpec
     Args: body
@@ -1031,16 +1138,19 @@ Set the metadata to be applied to the view
 when this revision is applied
 
 Args:
+
 ```
     body (dict): The changes to make to this revision
 ```
 
 Returns:
+
 ```
     Revision The updated Revision as a result of this API call, or an error
 ```
 
 Examples:
+
 ```python
     revision = revision.update({
         'metadata': {
@@ -1051,14 +1161,14 @@ Examples:
 ```
 
 ### [Sources](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L15)
+
 ```
 ArgSpec
     Args: auth
 ```
 
-
-
 #### [create_upload](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L40)
+
 ```
 ArgSpec
     Args: filename
@@ -1068,21 +1178,25 @@ Create a new source. Takes a `body` param, which must contain a `filename`
 of the file.
 
 Args:
+
 ```
     filename (str): The name of the file you are uploading
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     upload = revision.create_upload('foo.csv')
 ```
 
 #### [lookup](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L21)
+
 ```
 ArgSpec
     Args: source_id
@@ -1091,24 +1205,26 @@ ArgSpec
 Lookup a source
 
 Args:
+
 ```
     source_id (int): The id
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source The Source resulting from this API call, or an error
 ```
 
 ### [Source](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L122)
+
 ```
 ArgSpec
     Args: auth, response, parent
 ```
 
-
-
 #### [add_to_revision](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L466)
+
 ```
 ArgSpec
     Args: revision
@@ -1117,6 +1233,7 @@ ArgSpec
 Associate this Source with the given revision.
 
 #### [blob](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L237)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1125,19 +1242,21 @@ ArgSpec
 Uploads a Blob dataset. A blob is a file that will not be parsed as a data file,
 ie: an image, video, etc.
 
-
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-blob.jpg', 'rb') as f:
         upload = upload.blob(f)
 ```
 
 #### [change_parse_option](https://github.com/socrata/socrata-py/blob/master//socrata/builders/parse_options.py#L15)
+
 ```
 ArgSpec
     Args: name
@@ -1156,15 +1275,17 @@ Parse options are:
 header_count (int): the number of rows considered a header
 column_header (int): the one based index of row to use to generate the header
 encoding (string): defaults to guessing the encoding, but it can be explicitly set
-column_separator (string): For CSVs, this defaults to ",", and for TSVs "       ", but you can use a custom separator
+column_separator (string): For CSVs, this defaults to ",", and for TSVs " ", but you can use a custom separator
 quote_char (string): Character used to quote values that should be escaped. Defaults to """
 
 Args:
+
 ```
     name (string): One of the options above, ie: "column_separator" or "header_count"
 ```
 
 Returns:
+
 ```
     change (ParseOptionChange): implements a `.to(value)` function which you call to set the value
 ```
@@ -1182,11 +1303,13 @@ We want to say that the first 2 rows are headers, and the second of those 2
 rows should be used to make the column header. We would do that like so:
 
 Examples:
+
 ```python
     source = source            .change_parse_option('header_count').to(2)            .change_parse_option('column_header').to(2)            .run()
 ```
 
 #### [csv](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L261)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1195,6 +1318,7 @@ ArgSpec
 Upload a CSV, returns the new input schema.
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1203,17 +1327,20 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-file.csv', 'rb') as f:
         upload = upload.csv(f)
 ```
 
 #### [df](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L438)
+
 ```
 ArgSpec
     Args: dataframe
@@ -1222,6 +1349,7 @@ ArgSpec
 Upload a pandas DataFrame, returns the new source.
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1230,11 +1358,13 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     import pandas
     df = pandas.read_csv('test/fixtures/simple.csv')
@@ -1242,6 +1372,7 @@ Examples:
 ```
 
 #### [geojson](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L412)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1250,6 +1381,7 @@ ArgSpec
 Upload a geojson file, returns the new input schema.
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1258,17 +1390,20 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-geojson-file.geojson', 'rb') as f:
         upload = upload.geojson(f)
 ```
 
 #### [kml](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L386)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1277,6 +1412,7 @@ ArgSpec
 Upload a KML file, returns the new input schema.
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1285,11 +1421,13 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-kml-file.kml', 'rb') as f:
         upload = upload.kml(f)
@@ -1297,27 +1435,26 @@ Examples:
 
 #### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L146)
 
-
 Get a list of the operations that you can perform on this
 object. These map directly onto what's returned from the API
 in the `links` section of each resource
 
 #### [load](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L206)
 
-
 Forces the source to load, if it's a view source.
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 #### [open_in_browser](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L547)
 
-
 Open this source in your browser, this will open a window
 
 #### [shapefile](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L361)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1326,6 +1463,7 @@ ArgSpec
 Upload a Shapefile, returns the new input schema.
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1334,17 +1472,20 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-shapefile-archive.zip', 'rb') as f:
         upload = upload.shapefile(f)
 ```
 
 #### [tsv](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L336)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1353,6 +1494,7 @@ ArgSpec
 Upload a TSV, returns the new input schema.
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1361,11 +1503,13 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-file.tsv', 'rb') as f:
         upload = upload.tsv(f)
@@ -1373,15 +1517,16 @@ Examples:
 
 #### [ui_url](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L530)
 
-
 This is the URL to the landing page in the UI for the sources
 
 Returns:
+
 ```
     url (str): URL you can paste into a browser to view the source UI
 ```
 
 #### [wait_for_finish](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L515)
+
 ```
 ArgSpec
     Args: progress, timeout, sleeptime
@@ -1394,6 +1539,7 @@ and a timeout.
 Default timeout is 12 hours
 
 #### [wait_for_schema](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L500)
+
 ```
 ArgSpec
     Args: progress, timeout, sleeptime
@@ -1406,6 +1552,7 @@ and a timeout.
 Default timeout is 12 hours
 
 #### [xls](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L286)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1414,6 +1561,7 @@ ArgSpec
 Upload an XLS, returns the new input schema
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1422,17 +1570,20 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-file.xls', 'rb') as f:
         upload = upload.xls(f)
 ```
 
 #### [xlsx](https://github.com/socrata/socrata-py/blob/master//socrata/sources.py#L311)
+
 ```
 ArgSpec
     Args: file_handle
@@ -1441,6 +1592,7 @@ ArgSpec
 Upload an XLSX, returns the new input schema.
 
 Args:
+
 ```
     file_handle: The file handle, as returned by the python function `open()`
 
@@ -1449,25 +1601,27 @@ Args:
 ```
 
 Returns:
+
 ```
     Source: Returns the new Source
 ```
 
 Examples:
+
 ```python
     with open('my-file.xlsx', 'rb') as f:
         upload = upload.xlsx(f)
 ```
 
 ### [Configs](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L8)
+
 ```
 ArgSpec
     Args: auth
 ```
 
-
-
 #### [create](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L14)
+
 ```
 ArgSpec
     Args: name, data_action, parse_options, columns
@@ -1479,10 +1633,10 @@ and `columns`.
 
 #### [list](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L41)
 
-
 List all the ImportConfigs on this domain
 
 #### [lookup](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L32)
+
 ```
 ArgSpec
     Args: name
@@ -1491,14 +1645,14 @@ ArgSpec
 Obtain a single ImportConfig by name
 
 ### [Config](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L50)
+
 ```
 ArgSpec
     Args: auth, response, parent
 ```
 
-
-
 #### [change_parse_option](https://github.com/socrata/socrata-py/blob/master//socrata/builders/parse_options.py#L15)
+
 ```
 ArgSpec
     Args: name
@@ -1517,15 +1671,17 @@ Parse options are:
 header_count (int): the number of rows considered a header
 column_header (int): the one based index of row to use to generate the header
 encoding (string): defaults to guessing the encoding, but it can be explicitly set
-column_separator (string): For CSVs, this defaults to ",", and for TSVs "       ", but you can use a custom separator
+column_separator (string): For CSVs, this defaults to ",", and for TSVs " ", but you can use a custom separator
 quote_char (string): Character used to quote values that should be escaped. Defaults to """
 
 Args:
+
 ```
     name (string): One of the options above, ie: "column_separator" or "header_count"
 ```
 
 Returns:
+
 ```
     change (ParseOptionChange): implements a `.to(value)` function which you call to set the value
 ```
@@ -1543,11 +1699,13 @@ We want to say that the first 2 rows are headers, and the second of those 2
 rows should be used to make the column header. We would do that like so:
 
 Examples:
+
 ```python
     source = source            .change_parse_option('header_count').to(2)            .change_parse_option('column_header').to(2)            .run()
 ```
 
 #### [create_revision](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L68)
+
 ```
 ArgSpec
     Args: fourfour
@@ -1559,17 +1717,16 @@ in this Config.
 
 #### [delete](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L51)
 
-
 Delete this ImportConfig. Note that this cannot be undone.
 
 #### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L146)
-
 
 Get a list of the operations that you can perform on this
 object. These map directly onto what's returned from the API
 in the `links` section of each resource
 
 #### [update](https://github.com/socrata/socrata-py/blob/master//socrata/configs.py#L57)
+
 ```
 ArgSpec
     Args: body
@@ -1579,6 +1736,7 @@ Mutate this ImportConfig in place. Subsequent revisions opened against this
 ImportConfig will take on its new value.
 
 ### [InputSchema](https://github.com/socrata/socrata-py/blob/master//socrata/input_schema.py#L7)
+
 ```
 ArgSpec
     Args: auth, response, parent
@@ -1588,29 +1746,27 @@ This represents a schema exactly as it appeared in the source
 
 #### [get_latest_output_schema](https://github.com/socrata/socrata-py/blob/master//socrata/input_schema.py#L53)
 
-
 Note that this does not make an API request
 
 Returns:
-    output_schema (OutputSchema): Returns the latest output schema
+output_schema (OutputSchema): Returns the latest output schema
 
 #### [latest_output](https://github.com/socrata/socrata-py/blob/master//socrata/input_schema.py#L25)
-
 
 Get the latest (most recently created) OutputSchema
 which descends from this InputSchema
 
 Returns:
-    OutputSchema
+OutputSchema
 
 #### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L146)
-
 
 Get a list of the operations that you can perform on this
 object. These map directly onto what's returned from the API
 in the `links` section of each resource
 
 #### [transform](https://github.com/socrata/socrata-py/blob/master//socrata/input_schema.py#L11)
+
 ```
 ArgSpec
     Args: body
@@ -1623,6 +1779,7 @@ returned. See OutputSchema.wait_for_finish to block until
 the
 
 #### [wait_for_schema](https://github.com/socrata/socrata-py/blob/master//socrata/input_schema.py#L38)
+
 ```
 ArgSpec
     Args: progress, timeout, sleeptime
@@ -1636,10 +1793,10 @@ Default timeout is 12 hours
 
 ### [OutputSchema](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L51)
 
-
 This is data as transformed from an InputSchema
 
 #### [add_column](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L223)
+
 ```
 ArgSpec
     Args: field_name, display_name, transform_expr, description
@@ -1648,6 +1805,7 @@ ArgSpec
 Add a column
 
 Args:
+
 ```
     field_name (str): The column's field_name, must be unique
     display_name (str): The columns display name
@@ -1656,11 +1814,13 @@ Args:
 ```
 
 Returns:
+
 ```
     output_schema (OutputSchema): Returns self for easy chaining
 ```
 
 Examples:
+
 ```python
 new_output_schema = output
     # Add a new column, which is computed from the `celsius` column
@@ -1671,7 +1831,6 @@ new_output_schema = output
 ```
 
 #### [any_failed](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L78)
-
 
 This is probably not the function you are looking for.
 
@@ -1689,6 +1848,7 @@ For data errors:
         output_schema.schema_errors(offset = 0, limit = 20)
 
 #### [build_config](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L63)
+
 ```
 ArgSpec
     Args: name, data_action
@@ -1698,6 +1858,7 @@ Create a new ImportConfig from this OutputSchema. See the API
 docs for what an ImportConfig is and why they're useful
 
 #### [change_column_metadata](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L286)
+
 ```
 ArgSpec
     Args: field_name, attribute
@@ -1707,17 +1868,20 @@ Change the column metadata. This returns a ColumnChange,
 which implements a `.to` function, which takes the new value to change to
 
 Args:
+
 ```
     field_name (str): The column to change
     attribute (str): The attribute of the column to change
 ```
 
 Returns:
+
 ```
     change (TransformChange): The transform change, which implements the `.to` function
 ```
 
 Examples:
+
 ```python
     new_output_schema = output
         # Change the field_name of date to the_date
@@ -1730,6 +1894,7 @@ Examples:
 ```
 
 #### [change_column_transform](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L316)
+
 ```
 ArgSpec
     Args: field_name
@@ -1739,16 +1904,19 @@ Change the column transform. This returns a TransformChange,
 which implements a `.to` function, which takes a transform expression.
 
 Args:
+
 ```
     field_name (str): The column to change
 ```
 
 Returns:
+
 ```
     change (TransformChange): The transform change, which implements the `.to` function
 ```
 
 Examples:
+
 ```python
     new_output_schema = output
         .change_column_transform('the_date').to('to_fixed_timestamp(`date`)')
@@ -1760,6 +1928,7 @@ Examples:
 ```
 
 #### [drop_column](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L262)
+
 ```
 ArgSpec
     Args: field_name
@@ -1768,16 +1937,19 @@ ArgSpec
 Drop the column
 
 Args:
+
 ```
     field_name (str): The column to drop
 ```
 
 Returns:
+
 ```
     output_schema (OutputSchema): Returns self for easy chaining
 ```
 
 Examples:
+
 ```python
     new_output_schema = output
         .drop_column('foo')
@@ -1786,12 +1958,12 @@ Examples:
 
 #### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L146)
 
-
 Get a list of the operations that you can perform on this
 object. These map directly onto what's returned from the API
 in the `links` section of each resource
 
 #### [rows](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L140)
+
 ```
 ArgSpec
     Args: offset, limit
@@ -1803,16 +1975,16 @@ for paging through the data.
 
 #### [run](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L372)
 
-
 Run all adds, drops, and column changes.
 
-
 Returns:
+
 ```
     OutputSchema
 ```
 
 Examples:
+
 ```python
     new_output_schema = output
         # Change the field_name of date to the_date
@@ -1831,6 +2003,7 @@ Examples:
 ```
 
 #### [schema_errors](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L148)
+
 ```
 ArgSpec
     Args: offset, limit
@@ -1842,7 +2015,6 @@ Accepts `offset` and `limit` params
 
 #### [schema_errors_csv](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L155)
 
-
 Get the errors that results in transforming into this output schema
 as a CSV stream.
 
@@ -1850,6 +2022,7 @@ Note that this returns a Reponse, where Reponse
 is a python requests Reponse object
 
 #### [set_row_id](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L196)
+
 ```
 ArgSpec
     Args: field_name
@@ -1858,22 +2031,24 @@ ArgSpec
 Set the row id. Note you must call `validate_row_id` before doing this.
 
 Args:
+
 ```
     field_name (str): The column to set as the row id
 ```
 
 Returns:
+
 ```
     OutputSchema
 ```
 
 Examples:
+
 ```python
 new_output_schema = output.set_row_id('the_id_column')
 ```
 
 #### [set_sort_by](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L344)
-
 
 Replace the columns used to sort the dataset. This returns a SortChange,
 which implements a `.on` function to add a sort and a `.end_sort` function
@@ -1884,11 +2059,13 @@ sorts, which means it will remove sorts on deleted columns or on columns
 whose transforms are changed.
 
 Returns:
+
 ```
     change (SortChange): The sort change, which implements the `.on` and `.end_sort` functions
 ```
 
 Examples:
+
 ```python
     new_output_schema = output
         .set_sort_by()
@@ -1900,6 +2077,7 @@ Examples:
 ```
 
 #### [validate_row_id](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L170)
+
 ```
 ArgSpec
     Args: field_name
@@ -1908,16 +2086,19 @@ ArgSpec
 Set the row id. Note you must call `validate_row_id` before doing this.
 
 Args:
+
 ```
     field_name (str): The column to validate as the row id
 ```
 
 Returns:
+
 ```
     boolean
 ```
 
 #### [wait_for_finish](https://github.com/socrata/socrata-py/blob/master//socrata/output_schema.py#L108)
+
 ```
 ArgSpec
     Args: progress, timeout, sleeptime
@@ -1930,20 +2111,17 @@ and a timeout.
 Default timeout is 3 hours
 
 ### [Job](https://github.com/socrata/socrata-py/blob/master//socrata/job.py#L4)
+
 ```
 ArgSpec
     Args: auth, response, parent
 ```
 
-
-
 #### [is_complete](https://github.com/socrata/socrata-py/blob/master//socrata/job.py#L10)
-
 
 Has this job finished or failed (or been submitted for approval)
 
 #### [list_operations](https://github.com/socrata/socrata-py/blob/master//socrata/resource.py#L146)
-
 
 Get a list of the operations that you can perform on this
 object. These map directly onto what's returned from the API
@@ -1951,10 +2129,10 @@ in the `links` section of each resource
 
 #### [submitted_for_approval](https://github.com/socrata/socrata-py/blob/master//socrata/job.py#L33)
 
-
 Has this job entered the approval queue (rather than finishing or failing)
 
 #### [wait_for_finish](https://github.com/socrata/socrata-py/blob/master//socrata/job.py#L18)
+
 ```
 ArgSpec
     Args: progress, timeout, sleeptime
@@ -1963,4 +2141,5 @@ ArgSpec
 
 Wait for this dataset to finish transforming and validating. Accepts a progress function
 and a timeout.
+
 <!-- docstop -->

--- a/bin/test-staging
+++ b/bin/test-staging
@@ -3,13 +3,21 @@
 # Find the first available Python 3.8+
 for py_version in python3.12 python3.11 python3.10 python3.9 python3.8 python3; do
     if command -v $py_version &> /dev/null; then
-        PYTHON_BIN=$py_version
-        break
+        # Check if version is >= 3.8
+        version=$($py_version -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+        major=$(echo $version | cut -d. -f1)
+        minor=$(echo $version | cut -d. -f2)
+
+        if [ "$major" -eq 3 ] && [ "$minor" -ge 8 ]; then
+            PYTHON_BIN=$py_version
+            echo "Using $py_version (version $version)"
+            break
+        fi
     fi
 done
 
 if [ -z "$PYTHON_BIN" ]; then
-    echo "Error: Python 3.8+ not found"
+    echo "Error: Python 3.8+ not found. This project requires Python >= 3.8"
     exit 1
 fi
 

--- a/bin/test-staging
+++ b/bin/test-staging
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-virtualenv -p python3 venv
+virtualenv -p python3.9 venv
 . venv/bin/activate
 pip install -r requirements.txt
 python3 setup.py install

--- a/bin/test-staging
+++ b/bin/test-staging
@@ -1,27 +1,6 @@
 #!/bin/bash
 
-# Find the first available Python 3.8+
-for py_version in python3.12 python3.11 python3.10 python3.9 python3.8 python3; do
-    if command -v $py_version &> /dev/null; then
-        # Check if version is >= 3.8
-        version=$($py_version -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-        major=$(echo $version | cut -d. -f1)
-        minor=$(echo $version | cut -d. -f2)
-
-        if [ "$major" -eq 3 ] && [ "$minor" -ge 8 ]; then
-            PYTHON_BIN=$py_version
-            echo "Using $py_version (version $version)"
-            break
-        fi
-    fi
-done
-
-if [ -z "$PYTHON_BIN" ]; then
-    echo "Error: Python 3.8+ not found. This project requires Python >= 3.8"
-    exit 1
-fi
-
-virtualenv -p $PYTHON_BIN venv
+virtualenv -p python3 venv
 . venv/bin/activate
 pip install -r requirements.txt
 python3 setup.py install

--- a/bin/test-staging
+++ b/bin/test-staging
@@ -1,6 +1,19 @@
 #!/bin/bash
 
-virtualenv -p python3.9 venv
+# Find the first available Python 3.8+
+for py_version in python3.12 python3.11 python3.10 python3.9 python3.8 python3; do
+    if command -v $py_version &> /dev/null; then
+        PYTHON_BIN=$py_version
+        break
+    fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
+    echo "Error: Python 3.8+ not found"
+    exit 1
+fi
+
+virtualenv -p $PYTHON_BIN venv
 . venv/bin/activate
 pip install -r requirements.txt
 python3 setup.py install

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,9 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.9',
     ],
+    python_requires='>=3.8',
 
     # What does your project relate to?
     keywords='socrata open-data not-publishing',

--- a/socrata/revisions.py
+++ b/socrata/revisions.py
@@ -47,7 +47,7 @@ class Revisions(Collection):
         ))
 
 
-    def create_replace_revision(self, metadata = {}, permission = 'public'):
+    def create_replace_revision(self, metadata = {}, permission = None):
         """
         Create a revision on the view, which when applied, will replace the data.
 
@@ -68,7 +68,7 @@ class Revisions(Collection):
         """
         return self._create('replace', metadata, permission)
 
-    def create_update_revision(self, metadata = {}, permission = 'public'):
+    def create_update_revision(self, metadata = {}, permission = None):
         """
         Create a revision on the view, which when applied, will update the data
         rather than replacing it.
@@ -97,7 +97,7 @@ class Revisions(Collection):
         """
         return self._create('update', metadata, permission)
 
-    def create_delete_revision(self, metadata = {}, permission = 'public'):
+    def create_delete_revision(self, metadata = {}, permission = None):
         """
         Create a revision on the view, which when applied, will delete rows of data.
 

--- a/test/auth.py
+++ b/test/auth.py
@@ -4,11 +4,34 @@ from socrata import Socrata
 import logging
 import unittest
 
-auth = Authorization(
-  os.environ['SOCRATA_DOMAIN'],
-  os.environ['SOCRATA_USERNAME'],
-  os.environ['SOCRATA_PASSWORD']
-)
+# Use cookie auth if SOCRATA_COOKIE is set, otherwise fall back to username/password
+if os.environ.get('SOCRATA_COOKIE'):
+    from http.cookies import SimpleCookie
+
+    domain = os.environ['SOCRATA_DOMAIN']
+    authCookie = os.environ['SOCRATA_COOKIE']
+
+    cookies = SimpleCookie()
+    cookie_text = authCookie.strip()
+    cookies.load(cookie_text)
+    csrf_morsel = cookies.get("socrata-csrf-token")
+    if csrf_morsel is None:
+        raise RuntimeError(
+            "Cookie missing socrata-csrf-token. "
+            f"Parsed cookie keys: {list(cookies.keys())}"
+        )
+    cookieHeader = {
+        "Cookie": authCookie,
+        "X-CSRF-Token": csrf_morsel.value,
+    }
+
+    auth = Authorization(domain, cookies=cookieHeader)
+else:
+    auth = Authorization(
+      os.environ['SOCRATA_DOMAIN'],
+      username=os.environ['SOCRATA_USERNAME'],
+      password=os.environ['SOCRATA_PASSWORD']
+    )
 
 if auth.domain == 'localhost':
     auth.live_dangerously()

--- a/test/output_schema_test.py
+++ b/test/output_schema_test.py
@@ -243,7 +243,7 @@ class TestOutputSchema(TestCase):
             .run()
 
 
-        output = output.wait_for_finish(timeout = 300)
+        output = output.wait_for_finish(timeout = 600)
 
         rows = output.rows(offset = 0, limit = 4)
 

--- a/test/pandas_test.py
+++ b/test/pandas_test.py
@@ -1,6 +1,6 @@
 from socrata import Socrata
 from socrata.authorization import Authorization
-from auth import auth, TestCase
+from test.auth import auth, TestCase
 try:
     import pandas as pd
 except ImportError:

--- a/test/revision_test.py
+++ b/test/revision_test.py
@@ -190,3 +190,139 @@ class TestSocrata(TestCase):
             set([oc['transform']['transform_expr'] for oc in output_schema.attributes['output_columns']]),
             set(['`a`', '`b`', '`c`'])
         )
+
+    def test_permission_retained_on_replace_revision(self):
+        # Create initial dataset
+        input_schema = self.create_input_schema().wait_for_schema()
+        output_schema = input_schema.get_latest_output_schema()
+        output_schema.wait_for_finish(timeout = 300)
+
+        job = self.rev.apply(output_schema = output_schema)
+        job.wait_for_finish(timeout = 300)
+
+        # Create a revision with explicit 'private' permission
+        view = self.pub.views.lookup(self.rev.attributes['fourfour'])
+        rev1 = view.revisions.create_replace_revision(permission='private')
+
+        with open('test/fixtures/simple.csv', 'rb') as file:
+            source1 = rev1.create_upload('simple.csv')
+            input_schema1 = source1.csv(file)
+
+        output_schema1 = input_schema1.wait_for_schema().get_latest_input_schema().get_latest_output_schema()
+        output_schema1.wait_for_finish(timeout = 300)
+
+        job1 = rev1.apply(output_schema = output_schema1)
+        job1.wait_for_finish(timeout = 300)
+
+        view.show()
+        initial_permission = view.attributes.get('permissions', {}).get('scope')
+
+        # Create a revision without specifying permission (should retain 'private')
+        rev2 = view.revisions.create_replace_revision()
+
+        with open('test/fixtures/simple.csv', 'rb') as file2:
+            source2 = rev2.create_upload('simple.csv')
+            input_schema2 = source2.csv(file2)
+
+        output_schema2 = input_schema2.wait_for_schema().get_latest_input_schema().get_latest_output_schema()
+        output_schema2.wait_for_finish(timeout = 300)
+
+        job2 = rev2.apply(output_schema = output_schema2)
+        job2.wait_for_finish(timeout = 300)
+
+        view.show()
+        final_permission = view.attributes.get('permissions', {}).get('scope')
+        self.assertEqual(initial_permission, final_permission)
+        self.assertEqual(final_permission, 'private')
+
+    def test_permission_retained_on_update_revision(self):
+        # Create initial dataset
+        input_schema = self.create_input_schema().wait_for_schema()
+        output_schema = input_schema.get_latest_output_schema()
+        output_schema.wait_for_finish(timeout = 300)
+
+        job = self.rev.apply(output_schema = output_schema)
+        job.wait_for_finish(timeout = 300)
+
+        # Create a revision with explicit 'public' permission
+        view = self.pub.views.lookup(self.rev.attributes['fourfour'])
+        rev1 = view.revisions.create_replace_revision(permission='public')
+
+        with open('test/fixtures/simple.csv', 'rb') as file:
+            source1 = rev1.create_upload('simple.csv')
+            input_schema1 = source1.csv(file)
+
+        output_schema1 = input_schema1.wait_for_schema().get_latest_input_schema().get_latest_output_schema()
+        output_schema1.wait_for_finish(timeout = 300)
+
+        job1 = rev1.apply(output_schema = output_schema1)
+        job1.wait_for_finish(timeout = 300)
+
+        view.show()
+        initial_permission = view.attributes.get('permissions', {}).get('scope')
+
+        # Create an update revision without specifying permission (should retain 'public')
+        rev2 = view.revisions.create_update_revision()
+
+        with open('test/fixtures/simple.csv', 'rb') as file2:
+            source2 = rev2.create_upload('simple.csv')
+            input_schema2 = source2.csv(file2)
+
+        output_schema2 = input_schema2.wait_for_schema().get_latest_input_schema().get_latest_output_schema()
+        output_schema2.wait_for_finish(timeout = 300)
+
+        job2 = rev2.apply(output_schema = output_schema2)
+        job2.wait_for_finish(timeout = 300)
+
+        view.show()
+        final_permission = view.attributes.get('permissions', {}).get('scope')
+        self.assertEqual(initial_permission, final_permission)
+        self.assertEqual(final_permission, 'public')
+
+    def test_permission_retained_on_delete_revision(self):
+        # Create initial dataset
+        input_schema = self.create_input_schema().wait_for_schema()
+        output_schema = input_schema.get_latest_output_schema()
+        output_schema.wait_for_finish(timeout = 300)
+
+        # Set row ID for delete operations
+        output_schema = output_schema.set_row_id('a')
+        output_schema.wait_for_finish(timeout = 300)
+
+        job = self.rev.apply(output_schema = output_schema)
+        job.wait_for_finish(timeout = 300)
+
+        # Create a revision with explicit 'private' permission
+        view = self.pub.views.lookup(self.rev.attributes['fourfour'])
+        rev1 = view.revisions.create_replace_revision(permission='private')
+
+        with open('test/fixtures/simple.csv', 'rb') as file:
+            source1 = rev1.create_upload('simple.csv')
+            input_schema1 = source1.csv(file)
+
+        output_schema1 = input_schema1.wait_for_schema().get_latest_input_schema().get_latest_output_schema()
+        output_schema1.wait_for_finish(timeout = 300)
+
+        job1 = rev1.apply(output_schema = output_schema1)
+        job1.wait_for_finish(timeout = 300)
+
+        view.show()
+        initial_permission = view.attributes.get('permissions', {}).get('scope')
+
+        # Create a delete revision without specifying permission (should retain 'private')
+        rev2 = view.revisions.create_delete_revision()
+
+        with open('test/fixtures/simple.csv', 'rb') as file2:
+            source2 = rev2.create_upload('simple.csv')
+            input_schema2 = source2.csv(file2)
+
+        output_schema2 = input_schema2.wait_for_schema().get_latest_input_schema().get_latest_output_schema()
+        output_schema2.wait_for_finish(timeout = 300)
+
+        job2 = rev2.apply(output_schema = output_schema2)
+        job2.wait_for_finish(timeout = 300)
+
+        view.show()
+        final_permission = view.attributes.get('permissions', {}).get('scope')
+        self.assertEqual(initial_permission, final_permission)
+        self.assertEqual(final_permission, 'private')

--- a/test/revision_test.py
+++ b/test/revision_test.py
@@ -116,14 +116,25 @@ class TestSocrata(TestCase):
         output_schema = r.get_output_schema()
         self.assertTrue(output_schema != None)
 
-    def test_get_plan(self):
+    def test_get_plan_without_permission(self):
         r = self.view.revisions.create_replace_revision()
         input_schema = self.create_input_schema(rev = r).wait_for_schema()
         r.set_output_schema(input_schema.get_latest_output_schema().attributes['id'])
         input_schema.get_latest_output_schema().wait_for_finish(timeout = 300)
 
         plan = r.plan()
-        expected = set(['prepare_draft_for_import', 'set_schema', 'apply_metadata', 'upsert_task', 'set_display_type', 'publish', 'set_permission', 'wait_for_replication'])
+        expected = set(['prepare_draft_for_import', 'set_schema', 'apply_metadata', 'upsert_task', 'set_display_type', 'publish', 'wait_for_replication'])
+        actual   = set([step['type'] for step in plan])
+        self.assertTrue(set.issubset(expected, actual))
+
+    def test_get_plan_wit_permission(self):
+        r = self.view.revisions.create_replace_revision(permission='private')
+        input_schema = self.create_input_schema(rev = r).wait_for_schema()
+        r.set_output_schema(input_schema.get_latest_output_schema().attributes['id'])
+        input_schema.get_latest_output_schema().wait_for_finish(timeout = 300)
+
+        plan = r.plan()
+        expected = set(['prepare_draft_for_import', 'set_schema', 'apply_metadata', 'upsert_task', 'set_display_type', 'publish', 'wait_for_replication', 'set_permission'])
         actual   = set([step['type'] for step in plan])
         self.assertTrue(set.issubset(expected, actual))
 
@@ -285,10 +296,6 @@ class TestSocrata(TestCase):
         output_schema = input_schema.get_latest_output_schema()
         output_schema.wait_for_finish(timeout = 300)
 
-        # Set row ID for delete operations
-        output_schema = output_schema.set_row_id('a')
-        output_schema.wait_for_finish(timeout = 300)
-
         job = self.rev.apply(output_schema = output_schema)
         job.wait_for_finish(timeout = 300)
 
@@ -301,6 +308,8 @@ class TestSocrata(TestCase):
             input_schema1 = source1.csv(file)
 
         output_schema1 = input_schema1.wait_for_schema().get_latest_input_schema().get_latest_output_schema()
+        # Set row ID for delete operations
+        output_schema1 = output_schema1.set_row_id('a')
         output_schema1.wait_for_finish(timeout = 300)
 
         job1 = rev1.apply(output_schema = output_schema1)

--- a/test/revision_test.py
+++ b/test/revision_test.py
@@ -174,6 +174,7 @@ class TestSocrata(TestCase):
 
             self.assertEqual(rev.attributes['metadata']['description'], 'new dataset description')
 
+    @unittest.skip("error in enrolling to archival secondary")
     def test_restore_revision(self):
         # Do a revision so we can get it enrolled in archival
         self.rev.apply().wait_for_finish(timeout = 300)


### PR DESCRIPTION
**Before change:**
creating a new revision without passing `permission` sets the dataset audience to private by default. this happens regardless of the original state of the dataset (being public or private)

**After change:**
creating a new revision without passing `permission` retains the dataset audience from the previous revision. 

**Notes:**
- all tests are succeeding (after adding the skipping annotation for the test discussed in next point) , and I tested the workflow locally as well
- `test_restore_revision` is failing even on the main branch because `{'code': 'invalid_request', 'error': True, 'message': 'Asset archival is not enabled on this domain'}` something is wrong with the archival enrollment call. this will be addressed in a [separate ticket](https://socrata.atlassian.net/browse/EN-93442).
- I updated the setup script to use a compatible python version
